### PR TITLE
Default behavior for formatter is to preserve order of query.

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -75,8 +75,12 @@ const parseArgument = (accumulator, arg) => [
   ', ',
 ];
 
-exports.format = function(str) {
-  const ast = parse(str);
+const defaultOptions = {
+  preserveOrder: true,
+};
+
+exports.format = function(str, options = defaultOptions) {
+  const ast = parse(str, options);
   return R.join('', R.unnest([
     '{ ',
     parseChildren(ast.children),

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -88,14 +88,14 @@ function findQueryAndFragmentDeclarations(lexed, debug) {
   return result;
 }
 
-function parseFragmentDeclarations(fragmentDeclarations, debug) {
+function parseFragmentDeclarations(fragmentDeclarations, options) {
   return fragmentDeclarations.map((fragmentDefinition) => {
     const type = dict.FRAGMENT_DECLARATION;
     const typeReference = fragmentDefinition[3].value;
     const name = fragmentDefinition[1].value;
     const childrenToParse = fragmentDefinition.slice(4);
     const children = [];
-    recursiveParse(childrenToParse, debug, 0, { children });
+    recursiveParse(childrenToParse, options, 0, { children });
 
     return {
       type,
@@ -294,7 +294,8 @@ const printDebug = function(depth, items) {
   printTableForItems(columns, deeperItems, 4 * depthPadding);
 };
 
-const recursiveParse = function(lexed, debug = false, depth = 0, ast = makeRoot()) {
+const recursiveParse = function(lexed, options, depth = 0, ast = makeRoot()) {
+  const { preserveOrder, debug } = options;
   if (debug) {
     printDebug(depth, lexed);
   }
@@ -302,10 +303,6 @@ const recursiveParse = function(lexed, debug = false, depth = 0, ast = makeRoot(
   // Scalar children are leaf items for this depth
   // depth n's children are items at depth n + 1
   const nextDepth = depth + 1;
-  lexed
-    .filter(isScalar)
-    .filter((item) => item.depth === nextDepth)
-    .forEach((item) => ast.children.push(makeScalarNode(item, lexed)));
 
   // Find complex children groups, and add their recursively parsed definitions to our children list
   let childStartIndex = -1;
@@ -317,14 +314,16 @@ const recursiveParse = function(lexed, debug = false, depth = 0, ast = makeRoot(
       continue;
     }
 
+    if (isScalar(item)) {
+      ast.children.push(makeScalarNode(item, lexed));
+    } else if (isComplex(item)) {
     // GROUP_START tokens define a child's group children, but name of child is FIELD_BRANCH token before GROUP_START
-    if (isComplex(item)) {
       childStartIndex = index;
     } else if (childStartIndex > -1 && isGroupEnd(item)) {
       // GROUP_END corresponding to GROUP_START
       const childAndItsChildren = deeperItems.slice(childStartIndex, index + 1);
       const node = makeComplexNode(childAndItsChildren[0], childAndItsChildren);
-      const complexChildNode = recursiveParse(childAndItsChildren, debug, nextDepth, node);
+      const complexChildNode = recursiveParse(childAndItsChildren, options, nextDepth, node);
       ast.children.push(complexChildNode);
       childStartIndex = -1;
     } else if (item.definition === dict.FRAGMENT_NAME && deeperItems[index - 1].definition === dict.ELLIPSIS) {
@@ -346,20 +345,30 @@ const recursiveParse = function(lexed, debug = false, depth = 0, ast = makeRoot(
       const inlineFragmentTypeName = deeperItems[inlineFragmentStartIndex].value;
       const node = makeInlineFragmentNode(inlineFragmentTypeName);
       const fragmentAndItsChildren = deeperItems.slice(inlineFragmentStartIndex, index + 1);
-      const inlineFragmentNode = recursiveParse(fragmentAndItsChildren, debug, nextDepth, node);
+      const inlineFragmentNode = recursiveParse(fragmentAndItsChildren, options, nextDepth, node);
       ast.children.push(inlineFragmentNode);
       inlineFragmentStartIndex = -1;
     }
   }
 
-  // Sorting children, so that functionally equivalent graphql queries
-  // (with different orders for their requested fields) can deterministically produce the same AST
-  ast.children.sort(compareByName);
+  if (!preserveOrder) {
+    /*
+    Sorting children, so that functionally equivalent graphql queries
+    (with different orders for their requested fields) can deterministically produce the same AST
+     */
+    ast.children.sort(compareByName);
+  }
 
   return ast;
 };
 
-exports.parse = function(str, debug = false) {
+const defaultOptions = {
+  preserveOrder: true,
+  debug: false,
+};
+
+exports.parse = function(str, options = defaultOptions) {
+  const { debug } = options;
   const tokens = tokenize(str, debug);
 
   let lexed;
@@ -370,8 +379,8 @@ exports.parse = function(str, debug = false) {
   }
 
   const queryAndFragmentDeclarations = findQueryAndFragmentDeclarations(lexed, debug);
-  const root = recursiveParse(queryAndFragmentDeclarations.query, debug);
-  root.fragmentDeclarations = parseFragmentDeclarations(queryAndFragmentDeclarations.fragments, debug);
+  const root = recursiveParse(queryAndFragmentDeclarations.query, options);
+  root.fragmentDeclarations = parseFragmentDeclarations(queryAndFragmentDeclarations.fragments, options);
 
   try {
     verifyFragmentDeclarations(root, debug);

--- a/test/formatter.js
+++ b/test/formatter.js
@@ -19,11 +19,37 @@ describe('Formatter (whitespace stripper)', function() {
     others.forEach(query => expect(query).to.deep.equalInAnyOrder(first));
   }
 
-  function verifyFormatting(expected, input) {
-    const result = formatter.format(input);
+  function verifyFormatting(expected, input, options = { preserveOrder: true }) {
+    const result = formatter.format(input, options);
     expect(result).to.eql(expected);
     queriesProduceSameASTs(input, expected, result);
   }
+
+  it('default behavior is to preserve order of query', function() {
+    const query = `
+    {
+      b
+      a {
+        d
+        c
+      }
+    }`;
+    const expected = '{ b a { d c } }';
+    verifyFormatting(expected, query);
+  });
+
+  it('can be configured to sort alphabetically (per "depth")', function() {
+    const query = `
+    {
+      b
+      a {
+        d
+        c
+      }
+    }`;
+    const expected = '{ a { c d } b }';
+    verifyFormatting(expected, query, { preserveOrder: false });
+  });
 
   it('puts whitespace around curly braces and branch/leaf names', function() {
     const query = `
@@ -138,29 +164,29 @@ describe('Formatter (whitespace stripper)', function() {
 
     fragment Person on Roster {
       firstName
-      imageUrl
       lastName
+      imageUrl
     }
 
     fragment Record on TeamRecord {
+      wins
       losses
       ties
-      wins
     }
 
     fragment Logo on Image {
-      aspectRatio
       imageUrl
       primaryColor
       secondaryColor
+      aspectRatio
     }
 
     fragment TeamInfo on Franchise {
+      name
       description
       logo {
         ... Logo
       }
-      name
       record {
         ... Record
       }
@@ -172,10 +198,10 @@ describe('Formatter (whitespace stripper)', function() {
     const expected =
       '{ sport(league: "nhl") { franchise(name: "Avalanche") { ...TeamInfo ' +
       'rivals { ...TeamInfo } } } } ' +
-      'fragment Person on Roster { firstName imageUrl lastName } ' +
-      'fragment Record on TeamRecord { losses ties wins } ' +
-      'fragment Logo on Image { aspectRatio imageUrl primaryColor secondaryColor } ' +
-      'fragment TeamInfo on Franchise { description logo { ...Logo } name record { ...Record } roster { ...Person } }';
+      'fragment Person on Roster { firstName lastName imageUrl } ' +
+      'fragment Record on TeamRecord { wins losses ties } ' +
+      'fragment Logo on Image { imageUrl primaryColor secondaryColor aspectRatio } ' +
+      'fragment TeamInfo on Franchise { name description logo { ...Logo } record { ...Record } roster { ...Person } }';
     verifyFormatting(expected, query);
   });
 });


### PR DESCRIPTION
Can opt-in to 'sorted' format.  
Parser defaults to preserving order as well.  Can opt-in to 'sorted' AST